### PR TITLE
Fix known control flow issues

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -48,11 +48,11 @@
 
 (module kernel racket/base
 
-  (provide (rename-out [disposable* disposable]
-                       [make-disposable* make-disposable])
+  (provide (rename-out [disposable* disposable])
            acquire!
            disposable?
-           disposable/c)
+           disposable/c
+           make-disposable)
 
   (require racket/contract/base
            racket/function)
@@ -68,13 +68,6 @@
       (values v (thunk (dealloc v))))
     (make-disposable alloc+dealloc))
 
-  (define (make-disposable* proc)
-    (define (proc/no-breaks)
-      (define-values (v dispose!) (parameterize-break #f (proc)))
-      (define (dispose/no-breaks!) (parameterize-break #f (dispose!)))
-      (values v dispose/no-breaks!))
-    (make-disposable proc/no-breaks))
-
   (define (disposable/c value/c)
     (struct/c disposable (-> (values value/c any/c)))))
 
@@ -83,10 +76,15 @@
 ;; Safe caller interface
 
 (define (call/disposable disp f)
-  (define-values (v dispose!) (acquire! disp))
-  (dynamic-wind void
-                (thunk (call-with-continuation-barrier (thunk (f v))))
-                dispose!))
+  (define v-box (box #f))
+  (define dispose!-box (box #f))
+  (dynamic-wind (thunk
+                 (define-values (v dispose!) (acquire! disp))
+                 (set-box! v-box v)
+                 (set-box! dispose!-box dispose!))
+                (thunk
+                 (call-with-continuation-barrier (thunk (f (unbox v-box)))))
+                (thunk ((unbox dispose!-box)))))
 
 (define-simple-macro (with-disposable bindings:bindings body:expr ...+)
   (call/disposable (disposable-apply list bindings.expr ...)
@@ -106,10 +104,12 @@
 ;; Safe monadic compositional interface
 
 (define (map-async f vs)
-  (map force (for/list ([v (in-list vs)]) (delay (f v)))))
+  (map force (for/list ([v (in-list vs)]) (delay/thread (f v)))))
 
 (define (acquire/list! disp) (call-with-values (thunk (acquire! disp)) list))
-(define (acquire-all! disps) (map-async acquire/list! disps))
+
+(define (acquire-all! disps)
+  (map-async (λ (disp) (parameterize-break #f (acquire/list! disp))) disps))
 
 (define (disposable-pure v) (make-disposable (thunk (values v void))))
 
@@ -135,19 +135,22 @@
 (define (current-thread-dead) (thread-dead-evt (current-thread)))
 
 (define (acquire disp #:dispose-evt [evt (current-thread-dead)])
-  (define-values (v dispose!) (acquire! disp))
-  (thread (thunk (sync evt) (dispose!)))
-  v)
+  (parameterize-break #f
+    (define-values (v dispose!) (acquire! disp))
+    (thread (thunk (parameterize-break #f (sync evt) (dispose!))))
+    v))
 
 ;; Plumber-enabled globally allocated disposables
 
 (define (acquire-global disp #:plumber [plumber (current-plumber)])
-  (define-values (v dispose!) (acquire! disp))
-  (define (flush! handle)
-    (dispose!)
-    (plumber-flush-handle-remove! handle))
-  (plumber-add-flush! plumber flush!)
-  v)
+  (parameterize-break #f
+    (define-values (v dispose!) (acquire! disp))
+    (define (flush! handle)
+      (parameterize-break #f
+        (dispose!)
+        (plumber-flush-handle-remove! handle)))
+    (plumber-add-flush! plumber flush!)
+    v))
 
 ;; Async deallocation
 
@@ -155,7 +158,8 @@
   (make-disposable
    (λ ()
      (define-values (v dispose!) (acquire! disp))
-     (define (dispose-async!) (thread dispose!))
+     (define (dispose-async!)
+       (thread (thunk (parameterize-break #f (dispose!)))))
      (values v dispose-async!))))
 
 ;; Pooled disposables
@@ -175,8 +179,9 @@
                          #:max [max +inf.0]
                          #:max-idle [max-idle 10]
                          #:sync-release? [sync-release? #f])
-  (define (produce) (acquire/list! item-disp))
-  (define (release v-dispose-pair) ((second v-dispose-pair)))
+  (define (produce) (parameterize-break #f (acquire/list! item-disp)))
+  (define (release v-dispose-pair)
+    (parameterize-break #f ((second v-dispose-pair))))
   (define (lease-disposable* pool)
     ;; Leases can be returned asynchronously, but the pool itself is deallocated
     ;; synchronously. This enables a globally allocated pool to safely
@@ -193,4 +198,6 @@
 
 (define (acquire-virtual disp)
   (define thd-hash (make-weak-hash))
-  (thunk (hash-ref! thd-hash (current-thread) (thunk (acquire disp)))))
+  (thunk
+   (parameterize-break #f
+     (hash-ref! thd-hash (current-thread) (thunk (acquire disp))))))

--- a/main.rkt
+++ b/main.rkt
@@ -84,7 +84,9 @@
 
 (define (call/disposable disp f)
   (define-values (v dispose!) (acquire! disp))
-  (dynamic-wind void (thunk (f v)) dispose!))
+  (dynamic-wind void
+                (thunk (call-with-continuation-barrier (thunk (f v))))
+                dispose!))
 
 (define-simple-macro (with-disposable bindings:bindings body:expr ...+)
   (call/disposable (disposable-apply list bindings.expr ...)

--- a/private/test.rkt
+++ b/private/test.rkt
@@ -8,6 +8,7 @@
            disposable/example
            disposable/testing
            disposable/unsafe
+           racket/control
            racket/function
            racket/stxparam
            rackunit
@@ -90,6 +91,38 @@
     (with-foo-disp
       (check-exn values (thunk (call/disposable foo-disp raise)))
       (check-equal? (foo-log) '((alloc foo) (dealloc foo)))))
+
+  (test-case "call/disposable continuation barrier"
+    
+    (define (store-cc! a-box)
+      (call-with-composable-continuation
+       (λ (k) (set-box! a-box k))))
+
+    ;; Yes, this is magic
+    (define (call/capture proc)
+      (define k (box #f))
+      (call/prompt (thunk (proc (thunk (store-cc! k)))))
+      (thunk ((unbox k) (void))))
+
+    (with-foo-disp
+      (define (capture-in-disposable!)
+        (call/capture
+         (λ (capture!)
+           (with-disposable ([_ foo-disp])
+             (capture!)))))
+
+      ;; Attempting to re-enter a continuation captured inside of
+      ;; "with-disposable" should never succeed, because the disposable value
+      ;; used has already been deallocated. A new value could be allocated, but
+      ;; expressions evaluated before the captured continuation but still inside
+      ;; with-disposable will reference the old value that existed at the time
+      ;; of capture. Creating a new value upon re-entry would result in the pre-
+      ;; capture expressions referencing a different allocated value than the
+      ;; post-capture expressions. Thus, a continuation barrier is required.
+      (check-exn exn:fail:contract:continuation? capture-in-disposable!)
+      (check-equal? (foo-log) '((alloc foo) (dealloc foo)))))
+
+
   (test-case "acquire-virtual"
     (define-values (seq-disp seq-log)
       (disposable/event-log (sequence->disposable '(1 2 3))))

--- a/private/test.rkt
+++ b/private/test.rkt
@@ -86,6 +86,10 @@
       (call/disposable foo-disp check-call/disposable)
       (check-equal? (foo-log) '((alloc foo) (dealloc foo)))))
 
+  (test-case "call/disposable error"
+    (with-foo-disp
+      (check-exn values (thunk (call/disposable foo-disp raise)))
+      (check-equal? (foo-log) '((alloc foo) (dealloc foo)))))
   (test-case "acquire-virtual"
     (define-values (seq-disp seq-log)
       (disposable/event-log (sequence->disposable '(1 2 3))))

--- a/scribblings/main.scrbl
+++ b/scribblings/main.scrbl
@@ -189,7 +189,9 @@ allocation abstractions can be built.
 @defproc[(acquire! [disp disposable?]) (values any/c (-> void?))]{
  Returns a newly-allocated value with @racket[disp] as well as a thunk that
  deallocates the value when called. This is @emph{unsafe}, as the caller is
- responsible for ensuring that the deallocation thunk is called.
+ responsible for ensuring that the deallocation thunk is called. Both the
+ @racket[acquire!] procedure and the disposal thunk it returns should be called
+ with breaks disabled.
 
  @(disposable-examples
    (define-values (n dispose!) (acquire! example-disposable))


### PR DESCRIPTION
Closes #59 
Closes #56 

Also changes `call/disposable` to add a continuation barrier.

Code coverage is currently wonky because `define-logger` interacts poorly with `cover`.