### PR TITLE
Make disposable-test imply disposable

### DIFF
--- a/disposable-test/info.rkt
+++ b/disposable-test/info.rkt
@@ -2,11 +2,13 @@
 (define collection "disposable")
 (define version "0.1")
 (define deps
-  '("base"))
+  '("base"
+    ("disposable" #:version "0.2")))
 (define build-deps
-  '(("disposable" #:version "0.2")
-    "doc-coverage"
+  '("doc-coverage"
     "fixture"
     "rackunit-lib"))
 (define cover-omit-paths
   '("example.rkt")) ;; already tested by docs
+(define implies
+  '("disposable"))


### PR DESCRIPTION
Cooperates better with the package server’s “todos”