### PR TITLE
Reimplement atomic boxes

### DIFF
--- a/disposable/private/atomic-box.rkt
+++ b/disposable/private/atomic-box.rkt
@@ -115,6 +115,11 @@
         [else (raise-closed-error 'call/atomic-box b)]))
 
 (module+ test
+  (test-case "atomic-box-closed?"
+    (define b (atomic-box 'foo))
+    (check-false (atomic-box-closed? b))
+    (atomic-box-close! b)
+    (check-true (atomic-box-closed? b)))
   (test-case "atomic-box-ref"
     (define b (atomic-box 'foo))
     (check-equal? (atomic-box-ref b) 'foo)

--- a/disposable/private/atomic-box.rkt
+++ b/disposable/private/atomic-box.rkt
@@ -25,6 +25,9 @@
 (require racket/function
          racket/match)
 
+(module+ test
+  (require rackunit))
+
 ;; An atomic box contains a value that can have an update function applied to it
 ;; atomically in a separate kill-safe manager thread. The update function may
 ;; optionally return a value to the box client who requested the update. This
@@ -37,14 +40,14 @@
 (struct atomic-box (box thread)
   #:constructor-name make-atomic-box #:omit-define-syntaxes)
 
-(struct write-op (new-v) #:transparent)
+(struct write-op (new-v sema) #:transparent)
 (struct close-op (f) #:transparent)
 (struct update-op (f resp-channel) #:transparent)
 (struct call-op (f resp-channel) #:transparent)
 
 (define (loop b)
   (match (thread-receive)
-    [(write-op new-v) (set-box! b new-v) (loop b)]
+    [(write-op new-v sema) (set-box! b new-v) (semaphore-post sema) (loop b)]
     [(close-op f) (define v (unbox b)) (set-box! b closed) (f v)]
     [(update-op f ch)
      (define new-v (f (unbox b)))
@@ -67,6 +70,12 @@
 (define (atomic-box-closed? b)
   (thread-dead? (atomic-box-thread b)))
 
+(define (atomic-box-close! b #:on-close [on-close void])
+  (atomic-box-resume b)
+  (thread-send (atomic-box-thread b) (close-op on-close) void)
+  (sync (thread-dead-evt (atomic-box-thread b)))
+  (void))
+
 (define (raise-closed-error name b)
   (raise-argument-error name "(not/c atomic-box-closed?)" b))
 
@@ -79,15 +88,12 @@
   
 (define (atomic-box-set! b v #:handle-closed [handle #f])
   (atomic-box-resume b)
-  (define handle*
-    (or handle (thunk (raise-closed-error 'atomic-box-set! b))))
-  (thread-send (atomic-box-thread b) (write-op v) handle*))
-
-(define (atomic-box-close! b #:on-close [on-close void])
-  (atomic-box-resume b)
-  (thread-send (atomic-box-thread b) (close-op on-close) void)
-  (sync (thread-dead-evt (atomic-box-thread b)))
-  (void))
+  (define sema (make-semaphore))
+  (define (handle*)
+    (semaphore-post sema)
+    (if handle (handle) (raise-closed-error 'atomic-box-set! b)))
+  (begin0 (thread-send (atomic-box-thread b) (write-op v sema) handle*)
+          (semaphore-wait sema)))
 
 (define (atomic-box-update! b f #:return [return void]
                             #:handle-closed [handle #f])
@@ -107,3 +113,44 @@
          (channel-get ch)]
         [handle (handle)]
         [else (raise-closed-error 'call/atomic-box b)]))
+
+(module+ test
+  (test-case "atomic-box-ref"
+    (define b (atomic-box 'foo))
+    (check-equal? (atomic-box-ref b) 'foo)
+    (test-case "#:handle-closed"
+      (atomic-box-close! b)
+      (check-exn exn:fail:contract? (thunk (atomic-box-ref b)))
+      (check-equal? (atomic-box-ref b #:handle-closed (thunk 'bar)) 'bar)))
+  (test-case "atomic-box-set!"
+    (define b (atomic-box 'foo))
+    (check-equal? (atomic-box-set! b 'bar) (void))
+    (check-equal? (atomic-box-ref b) 'bar)
+    (test-case "#:handle-closed"
+      (atomic-box-close! b)
+      (check-exn exn:fail:contract? (thunk (atomic-box-set! b 'baz)))
+      (check-equal? (atomic-box-set! b 'baz #:handle-closed (thunk 'closed))
+                    'closed)))
+  (test-case "atomic-box-update!"
+    (define b (atomic-box 0))
+    (check-equal? (atomic-box-update! b add1) (void))
+    (check-equal? (atomic-box-ref b) 1)
+    (test-case "#:return"
+      (check-equal? (atomic-box-update! b add1 #:return -) -2))
+    (test-case "#:handle-closed"
+      (atomic-box-close! b)
+      (check-exn exn:fail:contract? (thunk (atomic-box-update! b add1)))
+      (check-equal? (atomic-box-update! b add1 #:handle-closed (thunk 'closed))
+                    'closed)))
+  (test-case "call/atomic-box"
+    (define b (atomic-box 5))
+    (define (incr-and-return-negate v) (values (add1 v) (- v)))
+    (check-equal? (call/atomic-box b incr-and-return-negate) -5)
+    (check-equal? (atomic-box-ref b) 6)
+    (test-case "#:handle-closed"
+      (atomic-box-close! b)
+      (check-exn exn:fail:contract?
+                 (thunk (call/atomic-box b incr-and-return-negate)))
+      (check-equal? (call/atomic-box b incr-and-return-negate
+                                     #:handle-closed (thunk 'closed))
+                    'closed))))

--- a/disposable/private/atomic-box.rkt
+++ b/disposable/private/atomic-box.rkt
@@ -107,12 +107,3 @@
          (channel-get ch)]
         [handle (handle)]
         [else (raise-closed-error 'call/atomic-box b)]))
-
-(define b (atomic-box 0))
-(define (count!)
-  (cond [(atomic-box-update! b add1 #:handle-closed (thunk #f))
-         (sleep 1)
-         (count!)]
-        [else
-         (displayln "Counter loop shutting down")]))
-(define counter (thread count!))

--- a/disposable/private/pool.rkt
+++ b/disposable/private/pool.rkt
@@ -89,7 +89,7 @@
 (define (pool-clear p)
   (define (clear s)
     (for-each/async (pool-release p) (stored-list s)))
-  (atomic-box-close (pool-stored p) #:on-close clear))
+  (atomic-box-close! (pool-stored p) #:on-close clear))
 
 (define (pool-return p l)
   (define (update s)

--- a/disposable/testing.rkt
+++ b/disposable/testing.rkt
@@ -35,7 +35,7 @@
 (define (make-event-log) (event-log (atomic-box (list))))
 (define (event-log-events elog) (atomic-box-ref (event-log-box elog)))
 
-(define (kill-event-log! elog) (atomic-box-close (event-log-box elog)))
+(define (kill-event-log! elog) (atomic-box-close! (event-log-box elog)))
 
 (define (log-event! elog type v)
   (define log (list type v))


### PR DESCRIPTION
New implementation doesn’t do everything in terms of `call/atomic`.
This way writing a value doesn’t need to send a response over a
channel, and reading a value doesn’t need to interact with the manager
thread at all.

Closes #86 