### PR TITLE
Automated Resyntax fixes

### DIFF
--- a/disposable/file.rkt
+++ b/disposable/file.rkt
@@ -12,9 +12,9 @@
                              (disposable/c path?))]
   [disposable-directory-logger logger?]))
 
-(require racket/file
-         disposable
+(require disposable
          disposable/unsafe
+         racket/file
          racket/function)
 
 (module+ test


### PR DESCRIPTION
This is an automated change generated by Resyntax.

#### Pass 1

Applied 1 fix to [`disposable/file.rkt`](../blob/HEAD/disposable/file.rkt)

  * Line 15, `tidy-require`: Keep imports in `require` sorted and grouped by phase, with collections before files.

## Summary

Fixed 1 issue in 1 file.

  * Fixed 1 occurrence of `tidy-require`

